### PR TITLE
IOS-5792: Add SPM dependencies support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .build/
 .vscode/launch.json
 .env
+xcuserdata/

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/tangem/grpc-swift.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "5318235c1bb4cb8943f6206e3ad65162551690d9"
+        "revision" : "b87db7e9e220926e42d9ecfc685c44b2ffb0d11a"
       }
     },
     {
@@ -168,7 +168,7 @@
       "location" : "https://github.com/tangem/swift-protobuf-binaries.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "7f7a414b093735ab5431d6a45b73868bcd55d5ac"
+        "revision" : "bb1cf0deaa34d288ed74e7f47c5274915ed90213"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/tangem/grpc-swift.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "bb8ee86a149e244ce63b71ac34dc5a2f7bd7f12a"
+        "revision" : "5318235c1bb4cb8943f6206e3ad65162551690d9"
       }
     },
     {
@@ -163,12 +163,12 @@
       }
     },
     {
-      "identity" : "swift-protobuf",
+      "identity" : "swift-protobuf-binaries",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tangem/swift-protobuf.git",
+      "location" : "https://github.com/tangem/swift-protobuf-binaries.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "9e56dadd3a3d865bd6ff44847cfc27305dc7b55e"
+        "revision" : "7f7a414b093735ab5431d6a45b73868bcd55d5ac"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -21,10 +21,10 @@
     {
       "identity" : "grpc-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/grpc/grpc-swift.git",
+      "location" : "https://github.com/tangem/grpc-swift.git",
       "state" : {
-        "revision" : "84bac657e9930d26e9124bac082f26586dc2d209",
-        "version" : "1.19.1"
+        "branch" : "feature/IOS-5792-SPM-dependencies-support",
+        "revision" : "bb8ee86a149e244ce63b71ac34dc5a2f7bd7f12a"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
-        "version" : "1.1.0"
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "d029d9d39c87bed85b1c50adee7c41795261a192",
+        "version" : "1.0.6"
       }
     },
     {
@@ -156,10 +156,10 @@
     {
       "identity" : "swift-protobuf",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-protobuf.git",
+      "location" : "https://github.com/tangem/swift-protobuf.git",
       "state" : {
-        "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
-        "version" : "1.23.0"
+        "branch" : "feature/IOS-5792-SPM-dependencies-support",
+        "revision" : "9e56dadd3a3d865bd6ff44847cfc27305dc7b55e"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tangem/grpc-swift.git",
       "state" : {
-        "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "04dbe855fff68a4062252a8cbc805de20a35c129"
+        "revision" : "d1d312e2547f0091341efb9f465791dd8380a24c",
+        "version" : "1.21.0-tangem1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
       "state" : {
-        "revision" : "db51c407d3be4a051484a141bf0bff36c43d3b1e",
-        "version" : "1.8.0"
+        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+        "version" : "1.8.1"
       }
     },
     {
@@ -91,12 +91,21 @@
       }
     },
     {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "12358d55a3824bd5fed310b999ea8cf83a9a1a65",
+        "version" : "1.0.3"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
       }
     },
     {
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
-        "version" : "2.59.0"
+        "revision" : "635b2589494c97e48c62514bc8b37ced762e0a62",
+        "version" : "2.63.0"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
-        "version" : "1.19.0"
+        "revision" : "363da63c1966405764f380c627409b2f9d9e710b",
+        "version" : "1.21.0"
       }
     },
     {
@@ -122,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "a8ccf13fa62775277a5d56844878c828bbb3be1a",
-        "version" : "1.27.0"
+        "revision" : "0904bf0feb5122b7e5c3f15db7df0eabe623dd87",
+        "version" : "1.30.0"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "320bd978cceb8e88c125dcbb774943a92f6286e9",
-        "version" : "2.25.0"
+        "revision" : "7c381eb6083542b124a6c18fae742f55001dc2b5",
+        "version" : "2.26.0"
       }
     },
     {
@@ -140,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-        "version" : "1.19.0"
+        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
+        "version" : "1.20.1"
       }
     },
     {
@@ -167,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "696b86a6d151578bca7c1a2a3ed419a5f834d40f",
-        "version" : "1.13.0"
+        "revision" : "8e68404f641300bfd0e37d478683bb275926760c",
+        "version" : "1.15.2"
       }
     },
     {
@@ -176,8 +185,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "025bcb1165deab2e20d4eaba79967ce73013f496",
+        "version" : "1.2.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
       "location" : "https://github.com/tangem/grpc-swift.git",
       "state" : {
         "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "b87db7e9e220926e42d9ecfc685c44b2ffb0d11a"
+        "revision" : "04dbe855fff68a4062252a8cbc805de20a35c129"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tangem/swift-protobuf-binaries.git",
       "state" : {
-        "branch" : "feature/IOS-5792-SPM-dependencies-support",
-        "revision" : "bb1cf0deaa34d288ed74e7f47c5274915ed90213"
+        "revision" : "de30521530591d98be12133724e3d78bc0524e41",
+        "version" : "1.25.2-tangem1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -85,7 +85,7 @@ let package = Package(
         .package(url: "https://github.com/objecthub/swift-numberkit.git", from: "2.4.1"),
         .package(url: "https://github.com/thebarndog/swift-dotenv.git", from: "1.0.0"),
         .package(url: "https://github.com/tangem/grpc-swift.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
-        .package(url: "https://github.com/tangem/swift-protobuf.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
+        .package(url: "https://github.com/tangem/swift-protobuf-binaries.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
         .package(url: "https://github.com/vsanthanam/AnyAsyncSequence.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         // swift-asn1 wants swift 5.7+ past 0.4
@@ -100,7 +100,7 @@ let package = Package(
         .target(
             name: "HederaProtobufs",
             dependencies: [
-                .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                .product(name: "SwiftProtobuf", package: "swift-protobuf-binaries"),
                 .product(name: "GRPC", package: "grpc-swift"),
             ]
         ),
@@ -115,7 +115,7 @@ let package = Package(
                 "HederaProtobufs",
                 "AnyAsyncSequence",
                 .product(name: "SwiftASN1", package: "swift-asn1"),
-                .product(name: "SwiftProtobuf", package: "swift-protobuf"),
+                .product(name: "SwiftProtobuf", package: "swift-protobuf-binaries"),
                 .product(name: "NumberKit", package: "swift-numberkit"),
                 .product(name: "GRPC", package: "grpc-swift"),
                 .product(name: "Atomics", package: "swift-atomics"),

--- a/Package.swift
+++ b/Package.swift
@@ -84,7 +84,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/objecthub/swift-numberkit.git", from: "2.4.1"),
         .package(url: "https://github.com/thebarndog/swift-dotenv.git", from: "1.0.0"),
-        .package(url: "https://github.com/tangem/grpc-swift.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
+        .package(url: "https://github.com/tangem/grpc-swift.git", exact: "1.21.0-tangem1"),
         .package(url: "https://github.com/tangem/swift-protobuf-binaries.git", exact: "1.25.2-tangem1"),
         .package(url: "https://github.com/vsanthanam/AnyAsyncSequence.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -85,7 +85,7 @@ let package = Package(
         .package(url: "https://github.com/objecthub/swift-numberkit.git", from: "2.4.1"),
         .package(url: "https://github.com/thebarndog/swift-dotenv.git", from: "1.0.0"),
         .package(url: "https://github.com/tangem/grpc-swift.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
-        .package(url: "https://github.com/tangem/swift-protobuf-binaries.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
+        .package(url: "https://github.com/tangem/swift-protobuf-binaries.git", exact: "1.25.2-tangem1"),
         .package(url: "https://github.com/vsanthanam/AnyAsyncSequence.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         // swift-asn1 wants swift 5.7+ past 0.4

--- a/Package.swift
+++ b/Package.swift
@@ -84,8 +84,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/objecthub/swift-numberkit.git", from: "2.4.1"),
         .package(url: "https://github.com/thebarndog/swift-dotenv.git", from: "1.0.0"),
-        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.16.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
+        .package(url: "https://github.com/tangem/grpc-swift.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
+        .package(url: "https://github.com/tangem/swift-protobuf.git", branch: "feature/IOS-5792-SPM-dependencies-support"),
         .package(url: "https://github.com/vsanthanam/AnyAsyncSequence.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
         // swift-asn1 wants swift 5.7+ past 0.4


### PR DESCRIPTION
[IOS-5792](https://tangem.atlassian.net/browse/IOS-5792)

- SPM зависимость `grpc-swift` заменена на форк, который использует binary xcframework `swift-protobuf-binaries` вместо обычного `SwiftProtobuf`
- сам SDK использует использует binary xcframework `swift-protobuf-binaries` вместо обычного `SwiftProtobuf`
- обновлены остальные зависимости

[IOS-5792]: https://tangem.atlassian.net/browse/IOS-5792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ