### PR TITLE
IOS-5870: Add one-to-one manual signing support

### DIFF
--- a/Sources/Hedera/TangemAdditions/Hedera+Tangem.swift
+++ b/Sources/Hedera/TangemAdditions/Hedera+Tangem.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Transaction {
+    /// - Note: Tangem addition.
+    public func signedTransactionsData() throws -> [Data] {
+        return try makeSources()
+            .signedTransactions
+            .map { $0.bodyBytes }
+    }
+}

--- a/Sources/Hedera/TangemAdditions/HederaProtobufs+Tangem.swift
+++ b/Sources/Hedera/TangemAdditions/HederaProtobufs+Tangem.swift
@@ -1,0 +1,11 @@
+import HederaProtobufs
+
+extension Proto_SignedTransaction {
+    /// - Note: Unmodified logic from `TransactionSources.signWithSigners(_:)`.
+    /// - Note: Tangem addition.
+    internal func isAlreadySignedWithPublicKey(_ publicKey: PublicKey) -> Bool {
+        let key = publicKey.toBytesRaw()
+
+        return sigMap.sigPair.contains { key.starts(with: $0.pubKeyPrefix) } ?? false
+    }
+}

--- a/Sources/Hedera/TangemAdditions/Transaction+Tangem.swift
+++ b/Sources/Hedera/TangemAdditions/Transaction+Tangem.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+extension Transaction {
+    /// Signs all of the transactions with the given signers.
+    /// - Note: Signs in a one-to-one fashion (one specific signer at a particular index is used to sign one specific transaction at the same index).
+    /// - Note: Tangem addition.
+    @discardableResult
+    public final func addSignatures(_ publicKey: PublicKey, _ signatures: [Data]) -> Self {
+        precondition(nodeAccountIds?.count == signatures.count, "The number of network nodes and the number of signatures do not match")
+
+        let signers = signatures.map { signature in
+            return Signer(publicKey) { _ in signature }
+        }
+
+        // swiftlint:disable:next force_try
+        let sources = try! makeSources()
+
+        self.sources = sources.signWithSignersOneToOne(signers)
+
+        return self
+    }
+}

--- a/Sources/Hedera/Transaction/TransactionSources.swift
+++ b/Sources/Hedera/Transaction/TransactionSources.swift
@@ -279,12 +279,7 @@ extension TransactionSources {
         var mutated: Bool = false
 
         for signer in signers {
-            let key = signer.publicKey.toBytesRaw()
-
-            let sigPairs = signedTransactions.first?.sigMap.sigPair
-
-            if sigPairs?.contains(where: { key.starts(with: $0.pubKeyPrefix) }) ?? false {
-                // this signer already signed these transactions.
+            if signedTransactions.first?.isAlreadySignedWithPublicKey(signer.publicKey) ?? false {
                 continue
             }
 


### PR DESCRIPTION
[IOS-5870](https://tangem.atlassian.net/browse/IOS-5870)

По дефолту, SDK поддерживает many-to-many (multi-sig) - когда несколько signers подписывают все транзакции.
Притом подписи добавляются последовательно и одним signer (с уникальным ключем) более одного раза подписывать нельзя.

Для нас же нужна one-to-one подпись - когда каждый signer подписывает свою транзакцию.

Кода вышло чуть больше, чем на андроид, так как:
1. На iOS под капотом юзается промежуточный DTO, `TransactionSources` вместо сразу протобафа
2. На iOS есть cow семантика у транзакций, которую надо бы сохранить

[IOS-5870]: https://tangem.atlassian.net/browse/IOS-5870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ