### PR TITLE
IOS-6648: Use safer approach for `Timestamp` initialization

### DIFF
--- a/Sources/Hedera/Timestamp.swift
+++ b/Sources/Hedera/Timestamp.swift
@@ -43,9 +43,11 @@ public struct Timestamp: Sendable, Equatable, Hashable, CustomStringConvertible,
     /// `Date` is stored as `Double` seconds, so, it may not have full precision.
     public init(from date: Date) {
         let components = Calendar.current.dateComponents([.second, .nanosecond], from: unixEpoch, to: date)
+        let seconds = components.second ?? .zero
+        let nanoseconds = components.nanosecond ?? .zero
 
-        seconds = UInt64(components.second!)
-        subSecondNanos = UInt32(components.nanosecond!)
+        self.seconds = UInt64(clamping: seconds)
+        self.subSecondNanos = UInt32(clamping: nanoseconds)
     }
 
     // todo: what do on overflow?


### PR DESCRIPTION
[IOS-6648](https://tangem.atlassian.net/browse/IOS-6648)

Некорректный таймштамп в худшем случае (который раньше вызывал креш из-за переполнения) по идее может грозить только тем, что нода в пуле нод не пропингуется (?) и ее статус будет некорректным

[IOS-6648]: https://tangem.atlassian.net/browse/IOS-6648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ